### PR TITLE
Show coach number and track number

### DIFF
--- a/app/FetchSchedule.elm
+++ b/app/FetchSchedule.elm
@@ -32,9 +32,11 @@ decodeSchedule =
 
 decodeTrain : Decode.Decoder Train
 decodeTrain =
-    Decode.map2 Train
+    Decode.map4 Train
         (Decode.field "scheduled_departure_utc" stringToDate)
         (Decode.maybe (Decode.field "predicted_departure_utc" stringToDate))
+        (Decode.maybe (Decode.field "track" Decode.string))
+        (Decode.maybe (Decode.field "coach_number" Decode.string))
 
 
 stringToDate : Decode.Decoder Date

--- a/app/Types.elm
+++ b/app/Types.elm
@@ -15,6 +15,8 @@ type alias Schedule =
 type alias Train =
     { scheduledDeparture : Date
     , predictedDeparture : Maybe Date
+    , track : Maybe String
+    , coach : Maybe String
     }
 
 


### PR DESCRIPTION
If an outbound train has a track number, we show that above the "departs
in" message. If an outbound train doesn't have a track number yet, but
has a coach number, we show that instead.

We only show this information for outbound trains, since it's really
only relevant when you're departing from a station with multiple tracks
(North or South Station).

Fixes https://github.com/thoughtbot/PurpleTrainElm/issues/11

# Example:

![simulator screen shot dec 8 2016 4 33 07 pm](https://cloud.githubusercontent.com/assets/180798/21028748/933b435c-bd64-11e6-9088-ed643a0105a8.png)
