### PR TITLE
Remove direction from model

### DIFF
--- a/app/DirectionPicker/View.elm
+++ b/app/DirectionPicker/View.elm
@@ -13,8 +13,7 @@ import ScrollableTabView exposing (..)
 view : List (Node Msg) -> Node Msg
 view =
     ScrollableTabView.view
-        [ Ui.on "ChangeTab" (Decode.succeed ChangeDirection)
-        , tabBarActiveTextColor Color.white
+        [ tabBarActiveTextColor Color.white
         , tabBarInactiveTextColor Color.lightHeader
         , tabBarUnderlineStyle
             [ Style.backgroundColor Color.lightHeader

--- a/app/Message.elm
+++ b/app/Message.elm
@@ -7,8 +7,7 @@ import NativeUi.AsyncStorage as AsyncStorage
 
 
 type Msg
-    = ChangeDirection
-    | PickStop Stop
+    = PickStop Stop
     | LoadStops (Result Http.Error Stops)
     | LoadSchedule Direction (Result Http.Error Schedule)
     | ToggleStopPicker

--- a/app/Model.elm
+++ b/app/Model.elm
@@ -7,8 +7,7 @@ import Types exposing (..)
 
 
 type alias Model =
-    { direction : Direction
-    , inboundSchedule : Loadable Schedule
+    { inboundSchedule : Loadable Schedule
     , outboundSchedule : Loadable Schedule
     , stops : Loadable Stops
     , selectedStop : Maybe Stop
@@ -19,8 +18,7 @@ type alias Model =
 
 initialModel : Model
 initialModel =
-    { direction = Inbound
-    , inboundSchedule = Loading
+    { inboundSchedule = Loading
     , outboundSchedule = Loading
     , stops = Loading
     , selectedStop = Nothing

--- a/app/Schedule/View.elm
+++ b/app/Schedule/View.elm
@@ -12,8 +12,8 @@ import Message exposing (..)
 import Model exposing (..)
 
 
-view : Model -> Schedule -> Node Msg
-view { direction, now } schedule =
+view : Model -> Direction -> Schedule -> Node Msg
+view { now } direction schedule =
     Elements.view
         []
         [ nextTrainsView direction now (nextTrains schedule)

--- a/app/Update.elm
+++ b/app/Update.elm
@@ -13,13 +13,6 @@ import NativeUi.AsyncStorage as AsyncStorage
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        ChangeDirection ->
-            let
-                newDirection =
-                    toggleDirection model.direction
-            in
-                ( { model | direction = newDirection }, Cmd.none )
-
         PickStop stop ->
             ( { model
                 | selectedStop = Just stop

--- a/app/View.elm
+++ b/app/View.elm
@@ -75,18 +75,18 @@ topSection model direction loadableSchedule =
         , Ui.property "tabLabel" (Json.Encode.string (directionString direction))
         , key (toString direction)
         ]
-        [ scheduleOrLoading model loadableSchedule
+        [ scheduleOrLoading model direction loadableSchedule
         ]
 
 
-scheduleOrLoading : Model -> Loadable Schedule -> Node Msg
-scheduleOrLoading model loadableSchedule =
+scheduleOrLoading : Model -> Direction -> Loadable Schedule -> Node Msg
+scheduleOrLoading model direction loadableSchedule =
     case loadableSchedule of
         Loading ->
             Elements.view [] []
 
         Ready schedule ->
-            Schedule.view model schedule
+            Schedule.view model direction schedule
 
 
 directionString : Direction -> String


### PR DESCRIPTION
We don't need to keep track of the current direction, because the
ScrollableTabView does this for us.