### PR TITLE
Fix bug showing "departing now" for 1h 0m

### DIFF
--- a/app/Api.elm
+++ b/app/Api.elm
@@ -1,0 +1,5 @@
+module Api exposing (..)
+
+
+baseUrl =
+    "https://commuter-api-production.herokuapp.com"

--- a/app/FetchSchedule.elm
+++ b/app/FetchSchedule.elm
@@ -6,6 +6,7 @@ import Json.Decode as Decode
 import Model exposing (..)
 import Message exposing (..)
 import Types exposing (..)
+import Api exposing (..)
 
 
 fetchSchedule : Direction -> Stop -> Cmd Msg
@@ -16,7 +17,8 @@ fetchSchedule direction stop =
 getSchedule : Direction -> Stop -> Http.Request Schedule
 getSchedule direction stop =
     Http.get
-        ("https://commuter-api-production.herokuapp.com/api/v2/stops/"
+        (baseUrl
+            ++ "/api/v2/stops/"
             ++ (Http.encodeUri stop)
             ++ "/"
             ++ toString direction

--- a/app/FetchStops.elm
+++ b/app/FetchStops.elm
@@ -4,6 +4,7 @@ import Http
 import Json.Decode as Decode
 import Message exposing (..)
 import Types exposing (..)
+import Api exposing (..)
 
 
 fetchStops : Cmd Msg
@@ -14,7 +15,7 @@ fetchStops =
 getStops : Http.Request Stops
 getStops =
     Http.get
-        "https://commuter-api-production.herokuapp.com/api/v2/stops"
+        (baseUrl ++ "/api/v2/stops")
         decodeStops
 
 

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,8 +11,7 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0", 
         "elm-lang/html": "2.0.0 <= v < 3.0.0", 
         "elm-lang/http": "1.0.0 <= v <= 1.0.0", 
-        "elm-native-ui/elm-native-ui": "2.0.0 <= v <= 2.0.0", 
-        "rluiten/elm-date-extra": "8.1.2 <= v < 9.0.0"
+        "elm-native-ui/elm-native-ui": "2.0.0 <= v <= 2.0.0"
     }, 
     "native-modules": true, 
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/elm-stuff/exact-dependencies.json
+++ b/elm-stuff/exact-dependencies.json
@@ -1,5 +1,4 @@
 {
-    "rluiten/elm-date-extra": "8.1.2", 
     "elm-lang/http": "1.0.0", 
     "elm-lang/virtual-dom": "2.0.1", 
     "elm-lang/html": "2.0.0", 


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/PurpleTrainElm/issues/14

This removes the elm-date-extra library, since it has a buggy
implementation of `Duration.diff`. The documentation for elm-date-extra
claims that this function returns a delta record with either all
positive values or all negative values, but we found that not to be the
case, which caused our logic to be wrong for showing the relative time
message.

This also adds an `Api` module to make it easier to point the
application to a separate base URL, e.g. to test the app against a local
API server.

Also fixes https://github.com/thoughtbot/PurpleTrainElm/issues/3 by only showing the late message if it is predicted to be >= 2 minutes late