### PR TITLE
Show activity indicator when loading schedule or stops

### DIFF
--- a/app/StopPickerButton/View.elm
+++ b/app/StopPickerButton/View.elm
@@ -29,7 +29,7 @@ picker : Model -> List (Node Msg)
 picker model =
     case model.stops of
         Loading ->
-            [ stopPickerButton "Loading" ]
+            [ loadingButton ]
 
         Ready (Err _) ->
             [ pickerError ]
@@ -91,16 +91,7 @@ maybeStopPicker model stops =
 stopPickerButton : String -> Node Msg
 stopPickerButton buttonLabel =
     Elements.touchableHighlight
-        [ Ui.style
-            [ Style.backgroundColor Color.stopPickerButton
-            , Style.borderRadius 40
-            , Style.height 56
-            , Style.justifyContent "center"
-            , Style.alignItems "center"
-            , Style.position "absolute"
-            , Style.bottom 20
-            , Style.width 270
-            ]
+        [ buttonStyles
         , onPress ToggleStopPicker
         , underlayColor Color.stopPickerButton
         ]
@@ -112,4 +103,30 @@ stopPickerButton buttonLabel =
                 ]
             ]
             [ Ui.string buttonLabel ]
+        ]
+
+
+loadingButton : Node Msg
+loadingButton =
+    Elements.touchableHighlight
+        [ buttonStyles
+        , underlayColor Color.stopPickerButton
+        ]
+        [ Elements.activityIndicator
+            [ Ui.style [ Style.alignSelf "stretch" ] ]
+            []
+        ]
+
+
+buttonStyles : Ui.Property Msg
+buttonStyles =
+    Ui.style
+        [ Style.backgroundColor Color.stopPickerButton
+        , Style.borderRadius 40
+        , Style.height 56
+        , Style.justifyContent "center"
+        , Style.alignItems "center"
+        , Style.position "absolute"
+        , Style.bottom 20
+        , Style.width 270
         ]

--- a/app/View.elm
+++ b/app/View.elm
@@ -84,7 +84,18 @@ scheduleOrLoading : Model -> Direction -> Loadable (Result Http.Error Schedule) 
 scheduleOrLoading model direction loadableSchedule =
     case loadableSchedule of
         Loading ->
-            Elements.view [] []
+            Elements.view
+                [ Ui.style
+                    [ Style.flex 1
+                    , Style.flexDirection "column"
+                    , Style.alignSelf "stretch"
+                    , Style.justifyContent "center"
+                    ]
+                ]
+                [ Elements.activityIndicator
+                    [ Ui.style [ Style.alignSelf "stretch" ] ]
+                    []
+                ]
 
         Ready (Err _) ->
             Elements.view


### PR DESCRIPTION
When loading a schedule, show the activity indicator in the middle of
the screen.

When loading the stops, show the activity indicator inside the stops
button.

Fixes https://github.com/thoughtbot/PurpleTrainElm/issues/23