### PR TITLE
Use api at purpletrainapp.com

### DIFF
--- a/app/Api.elm
+++ b/app/Api.elm
@@ -2,4 +2,4 @@ module Api exposing (..)
 
 
 baseUrl =
-    "https://commuter-api-production.herokuapp.com"
+    "https://purpletrainapp.com"

--- a/ios/PurpleTrain/Info.plist
+++ b/ios/PurpleTrain/Info.plist
@@ -28,11 +28,6 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>commuter-api-production.herokuapp.com</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<string></string>
-			</dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>


### PR DESCRIPTION
This is the new production URL where both the website and the API live.
As part of this change, I also removed the insecure URL exception for
the API host as we are using SSL there.