### PR TITLE
Design tweaks for alerts

### DIFF
--- a/app/App/Color.elm
+++ b/app/App/Color.elm
@@ -1,6 +1,10 @@
 module App.Color exposing (..)
 
 
+dismissColor =
+    "#acacac"
+
+
 purple =
     "#5C4570"
 

--- a/app/DirectionPicker/View.elm
+++ b/app/DirectionPicker/View.elm
@@ -17,12 +17,17 @@ view =
         , tabBarInactiveTextColor Color.lightHeader
         , tabBarUnderlineStyle
             [ Style.backgroundColor Color.lightHeader
-            , Style.height 1
+            , Style.height 0
             ]
         , tabBarTextStyle
             [ Style.fontFamily Font.hkCompakt
             , Style.fontWeight "400"
             , Style.fontSize 20
             ]
-        , Ui.style [ Style.marginTop 20 ]
+        , tabBarStyle
+            [ Style.borderBottomWidth 0
+            ]
+        , Ui.style
+            [ Style.marginTop 20
+            ]
         ]

--- a/app/Schedule/Alerts/View.elm
+++ b/app/Schedule/Alerts/View.elm
@@ -5,6 +5,7 @@ import Maybe exposing (..)
 import NativeUi as Ui exposing (Node)
 import NativeUi.Elements as Elements exposing (..)
 import NativeUi.Events exposing (..)
+import NativeUi.Properties exposing (..)
 import NativeUi.Style as Style
 import App.Color as Color
 import App.Maybe exposing (..)
@@ -47,20 +48,39 @@ renderAlerts alertsAreExpanded allAlerts dismissedAlertIds =
 
 alertsBanner : Bool -> Int -> Node Msg
 alertsBanner alertsAreExpanded alertCount =
-    text
+    Elements.touchableOpacity
         [ Ui.style
-            [ Style.backgroundColor Color.lightGray
-            , Style.color Color.red
-            , Style.fontSize 9
-            , Style.fontWeight "700"
-            , Style.letterSpacing 0.25
-            , Style.paddingBottom 18
-            , Style.paddingTop 18
-            , Style.textAlign "center"
+            [ Style.backgroundColor Color.red
+            , Style.paddingHorizontal 8
+            , Style.paddingVertical 18
+            , Style.flexDirection "row"
+            , Style.alignItems "center"
             ]
         , onPress ToggleAlerts
+        , activeOpacity 0.7
         ]
-        [ Ui.string <| alertsBannerText alertsAreExpanded alertCount ]
+        [ text
+            [ Ui.style
+                [ Style.flex 1
+                , Style.color "#fff"
+                ]
+            ]
+            [ Ui.string <| arrowCharacter alertsAreExpanded ]
+        , text
+            [ Ui.style
+                [ Style.color Color.lightGray
+                , Style.fontSize 14
+                , Style.fontWeight "700"
+                , Style.letterSpacing 0.25
+                , Style.textAlign "center"
+                , Style.flex 2
+                ]
+            ]
+            [ Ui.string <| alertsBannerText alertCount ]
+        , Elements.view
+            [ Ui.style [ Style.flex 1 ] ]
+            []
+        ]
 
 
 maybeExpandedAlerts : Bool -> Alerts -> Maybe (Node Msg)
@@ -80,8 +100,8 @@ expandedAlert : Alert -> Node Msg
 expandedAlert alert =
     Elements.view
         [ Ui.style
-            [ Style.borderTopWidth 1
-            , Style.borderTopColor Color.darkGray
+            [ Style.borderBottomWidth 1
+            , Style.borderBottomColor Color.darkGray
             , Style.paddingHorizontal 18
             , Style.paddingVertical 18
             ]
@@ -91,6 +111,7 @@ expandedAlert alert =
                 [ Style.flex 1
                 , Style.flexDirection "row"
                 , Style.marginBottom 4
+                , Style.alignItems "center"
                 ]
             ]
             [ text
@@ -98,24 +119,22 @@ expandedAlert alert =
                     [ Style.fontWeight "700"
                     , Style.fontSize 14
                     , Style.flex 1
+                    , Style.lineHeight 30
                     ]
                 ]
                 [ Ui.string alert.effectName ]
             , Elements.view
                 [ Ui.style
-                    [ Style.borderWidth 1
-                    , Style.borderColor Color.purple
-                    , Style.borderRadius 3
-                    , Style.padding 2
+                    [ Style.padding 2
                     ]
                 ]
                 [ text
                     [ onPress <| DismissAlert alert
                     , Ui.style
-                        [ Style.color Color.purple
+                        [ Style.color Color.dismissColor
                         ]
                     ]
-                    [ Ui.string "Dismiss" ]
+                    [ Ui.string "dismiss" ]
                 ]
             ]
         , text
@@ -124,15 +143,9 @@ expandedAlert alert =
         ]
 
 
-alertsBannerText : Bool -> Int -> String
-alertsBannerText alertsAreExpanded alertCount =
+alertsBannerText : Int -> String
+alertsBannerText alertCount =
     let
-        arrowCharacter =
-            if alertsAreExpanded then
-                "▲"
-            else
-                "▼"
-
         pluralizedDescription =
             if alertCount == 1 then
                 "ALERT"
@@ -141,8 +154,14 @@ alertsBannerText alertsAreExpanded alertCount =
     in
         String.join
             " "
-            [ arrowCharacter
-            , toString alertCount
+            [ toString alertCount
             , pluralizedDescription
-            , arrowCharacter
             ]
+
+
+arrowCharacter : Bool -> String
+arrowCharacter alertsAreExpanded =
+    if alertsAreExpanded then
+        "▼"
+    else
+        "▶"

--- a/app/ScrollableTabView.elm
+++ b/app/ScrollableTabView.elm
@@ -5,6 +5,7 @@ module ScrollableTabView
         , tabBarInactiveTextColor
         , tabBarUnderlineStyle
         , tabBarTextStyle
+        , tabBarStyle
         )
 
 import NativeUi as NativeUi exposing (Property, Node)
@@ -36,3 +37,8 @@ tabBarUnderlineStyle =
 tabBarTextStyle : List Style.Style -> Property msg
 tabBarTextStyle =
     NativeUi.property "tabBarTextStyle" << Style.encode
+
+
+tabBarStyle : List Style.Style -> Property msg
+tabBarStyle =
+    NativeUi.property "tabBarStyle" << Style.encode

--- a/app/StopPicker/View.elm
+++ b/app/StopPicker/View.elm
@@ -15,10 +15,7 @@ import ViewHelpers exposing (..)
 
 view : Stops -> Node Msg
 view stops =
-    pickerContainer
-        [ pickerHeader "Select home stop"
-        , stopOptions stops
-        ]
+    pickerContainer [ stopOptions stops ]
 
 
 stopOptions : Stops -> Node Msg
@@ -37,30 +34,10 @@ pickerOptions =
     Elements.scrollView
         [ Ui.style
             [ Style.backgroundColor Color.white
-            , Style.borderBottomLeftRadius 10
-            , Style.borderBottomRightRadius 10
+            , Style.borderRadius 10
+            , Style.borderRadius 10
             , Style.height 252
             ]
-        ]
-
-
-pickerHeader : String -> Node Msg
-pickerHeader label =
-    Elements.view
-        [ Ui.style
-            [ Style.backgroundColor Color.red
-            , Style.borderTopLeftRadius 10
-            , Style.borderTopRightRadius 10
-            , Style.padding 10
-            ]
-        ]
-        [ text
-            [ Ui.style
-                [ Style.color Color.white
-                , Style.fontFamily Font.hkCompakt
-                ]
-            ]
-            [ Ui.string label ]
         ]
 
 

--- a/app/StopPickerButton/View.elm
+++ b/app/StopPickerButton/View.elm
@@ -90,10 +90,10 @@ maybeStopPicker model stops =
 
 stopPickerButton : String -> Node Msg
 stopPickerButton buttonLabel =
-    Elements.touchableHighlight
+    Elements.touchableOpacity
         [ buttonStyles
         , onPress ToggleStopPicker
-        , underlayColor Color.stopPickerButton
+        , activeOpacity 0.7
         ]
         [ text
             [ Ui.style
@@ -108,9 +108,9 @@ stopPickerButton buttonLabel =
 
 loadingButton : Node Msg
 loadingButton =
-    Elements.touchableHighlight
+    Elements.touchableOpacity
         [ buttonStyles
-        , underlayColor Color.stopPickerButton
+        , activeOpacity 0.7
         ]
         [ Elements.activityIndicator
             [ Ui.style [ Style.alignSelf "stretch" ] ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "react": "15.3.2",
     "react-native": "0.36.0",
-    "react-native-scrollable-tab-view": "^0.7.0"
+    "react-native-scrollable-tab-view": "https://github.com/iancanderson/react-native-scrollable-tab-view.git#ia-tabbar-style-prop"
   },
   "jest": {
     "preset": "jest-react-native"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3955,6 +3955,12 @@ react-native-scrollable-tab-view@^0.7.0:
   dependencies:
     react-timer-mixin "^0.13.3"
 
+"react-native-scrollable-tab-view@https://github.com/iancanderson/react-native-scrollable-tab-view.git#ia-tabbar-style-prop":
+  version "0.7.1"
+  resolved "https://github.com/iancanderson/react-native-scrollable-tab-view.git#651581d0887e9ca42909e102c75cec896e501964"
+  dependencies:
+    react-timer-mixin "^0.13.3"
+
 react-native@0.36.0:
   version "0.36.0"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.36.0.tgz#3ce19cebcf99e2dc5a889cbb74201ef63ecb6a55"


### PR DESCRIPTION
- Alerts dismiss button:
  - Remove border, lowercase, increase line height, center vertically
    with alert header
- Alert banner:
  - Background is red/orange
  - Arrow points right (collapsed) or down (expanded)
- Remove tab underline and bottom border
  - I made a PR to the tab bar library to make this possible:
https://github.com/skv-headless/react-native-scrollable-tab-view/pull/537
  - In the meantime, this points us at my fork so we can pass
`tabBarStyle`.
- Make it more obvious when tapping stop button
- Remove unnecessary stop picker header

![purple_train_alerts_styled_final](https://cloud.githubusercontent.com/assets/180798/22383541/3cce9504-e498-11e6-95ba-9b5997f33f11.gif)


Higher-res screenshot:

![simulator screen shot jan 27 2017 1 55 43 pm](https://cloud.githubusercontent.com/assets/180798/22383564/53495ee0-e498-11e6-990d-1712333f1410.png)
