### PR TITLE
Show initial tab based on time of day

### DIFF
--- a/app/DirectionPicker/View.elm
+++ b/app/DirectionPicker/View.elm
@@ -4,16 +4,19 @@ import NativeUi as Ui exposing (Node, Property)
 import NativeUi.Style as Style
 import Json.Decode as Decode
 import Json.Encode
+import Date exposing (Date)
 import App.Color as Color
 import App.Font as Font
 import Message exposing (..)
 import ScrollableTabView exposing (..)
+import Model exposing (Model)
 
 
-view : List (Node Msg) -> Node Msg
-view =
+view : Model -> List (Node Msg) -> Node Msg
+view { now } =
     ScrollableTabView.view
-        [ tabBarActiveTextColor Color.white
+        [ initialPage <| getInitialPageIndex now
+        , tabBarActiveTextColor Color.white
         , tabBarInactiveTextColor Color.lightHeader
         , tabBarUnderlineStyle
             [ Style.backgroundColor Color.lightHeader
@@ -31,3 +34,23 @@ view =
             [ Style.marginTop 20
             ]
         ]
+
+
+getInitialPageIndex : Date -> Int
+getInitialPageIndex date =
+    let
+        inboundTabIndex =
+            0
+
+        outboundTabIndex =
+            1
+    in
+        if isTimeToGoHome date then
+            outboundTabIndex
+        else
+            inboundTabIndex
+
+
+isTimeToGoHome : Date -> Bool
+isTimeToGoHome date =
+    Date.hour date >= 13

--- a/app/ScrollableTabView.elm
+++ b/app/ScrollableTabView.elm
@@ -1,6 +1,7 @@
 module ScrollableTabView
     exposing
         ( view
+        , initialPage
         , tabBarActiveTextColor
         , tabBarInactiveTextColor
         , tabBarUnderlineStyle
@@ -17,6 +18,11 @@ import Json.Encode
 view : List (Property msg) -> List (Node msg) -> Node msg
 view =
     NativeUi.customNode "ScrollableTabView" Native.ScrollableTabView.view
+
+
+initialPage : Int -> Property msg
+initialPage =
+    NativeUi.property "initialPage" << Json.Encode.int
 
 
 tabBarActiveTextColor : String -> Property msg

--- a/app/View.elm
+++ b/app/View.elm
@@ -53,6 +53,7 @@ mainView model =
                 catMaybes
                     [ Just <|
                         DirectionPicker.view
+                            model
                             [ topSection model Inbound model.inboundSchedule
                             , topSection model Outbound model.outboundSchedule
                             ]


### PR DESCRIPTION
When opening the app, if it's 1pm or later, the app assumes that you
want to go home, so it automatically selects the outbound tab. Before
1pm it shows inbound trains.


## Time to go home!

![simulator screen shot jan 27 2017 3 53 15 pm](https://cloud.githubusercontent.com/assets/180798/22387250/b90f61ce-e4a8-11e6-920f-bd2b2aa5e3e3.png)
