### PR TITLE
Collapse type signature

### DIFF
--- a/app/Model.elm
+++ b/app/Model.elm
@@ -9,15 +9,15 @@ import Types exposing (..)
 
 
 type alias Model =
-    { inboundSchedule : Loadable (Result Http.Error Schedule)
-    , outboundSchedule : Loadable (Result Http.Error Schedule)
+    { inboundSchedule : Loadable Schedule
+    , outboundSchedule : Loadable Schedule
     , selectedStop : Maybe Stop
     , stopPickerOpen : Bool
     , now : Date
-    , alerts : Loadable (Result Http.Error Alerts)
+    , alerts : Loadable Alerts
     , alertsAreExpanded : Bool
     , dismissedAlertIds : List Int
-    , stopPickerDataSource : Loadable (Result Http.Error (DataSource Stop))
+    , stopPickerDataSource : Loadable (DataSource Stop)
     }
 
 
@@ -67,11 +67,8 @@ visibleAlerts allAlerts dismissedIds =
 visibleAlertsExist : Model -> Bool
 visibleAlertsExist { alerts, dismissedAlertIds } =
     case alerts of
-        Loading ->
-            False
-
-        Ready (Err _) ->
-            False
-
-        Ready (Ok loadedAlerts) ->
+        Ready loadedAlerts ->
             not <| List.isEmpty <| visibleAlerts loadedAlerts dismissedAlertIds
+
+        _ ->
+            False

--- a/app/Schedule/Alerts/View.elm
+++ b/app/Schedule/Alerts/View.elm
@@ -16,14 +16,11 @@ import Types exposing (..)
 view : Model -> Maybe (Node Msg)
 view { alertsAreExpanded, alerts, dismissedAlertIds } =
     case alerts of
-        Loading ->
-            Nothing
-
-        Ready (Err _) ->
-            Nothing
-
-        Ready (Ok loadedAlerts) ->
+        Ready loadedAlerts ->
             renderAlerts alertsAreExpanded loadedAlerts dismissedAlertIds
+
+        _ ->
+            Nothing
 
 
 renderAlerts : Bool -> List Alert -> List Int -> Maybe (Node Msg)

--- a/app/StopPickerButton/View.elm
+++ b/app/StopPickerButton/View.elm
@@ -32,10 +32,10 @@ picker model =
         Loading ->
             [ loadingButton ]
 
-        Ready (Err _) ->
+        Error ->
             [ pickerError ]
 
-        Ready (Ok dataSource) ->
+        Ready dataSource ->
             catMaybes
                 [ maybeStopPicker model dataSource
                 , Just <| stopPickerButton <| stopPickerLabelText model

--- a/app/Types.elm
+++ b/app/Types.elm
@@ -42,4 +42,5 @@ type alias Stop =
 
 type Loadable a
     = Loading
+    | Error
     | Ready a

--- a/app/View.elm
+++ b/app/View.elm
@@ -73,7 +73,7 @@ welcomeScreen =
         [ Ui.string "Purple Train" ]
 
 
-topSection : Model -> Direction -> Loadable (Result Http.Error Schedule) -> Node Msg
+topSection : Model -> Direction -> Loadable Schedule -> Node Msg
 topSection model direction loadableSchedule =
     Elements.view
         [ Ui.style
@@ -88,7 +88,7 @@ topSection model direction loadableSchedule =
         ]
 
 
-scheduleOrLoading : Model -> Direction -> Loadable (Result Http.Error Schedule) -> Node Msg
+scheduleOrLoading : Model -> Direction -> Loadable Schedule -> Node Msg
 scheduleOrLoading model direction loadableSchedule =
     case loadableSchedule of
         Loading ->
@@ -105,7 +105,7 @@ scheduleOrLoading model direction loadableSchedule =
                     []
                 ]
 
-        Ready (Err _) ->
+        Error ->
             Elements.view
                 [ Ui.style
                     [ Style.flex 1
@@ -127,7 +127,7 @@ scheduleOrLoading model direction loadableSchedule =
                     [ Ui.string "Error while connecting to server" ]
                 ]
 
-        Ready (Ok schedule) ->
+        Ready schedule ->
             Schedule.view model direction schedule
 
 


### PR DESCRIPTION
Instead of having 6 potential states and having to regularly destructure
the nested types, we decided we could collapse the types to make
destructuring easier.