### PR TITLE
Hack to show border radius on Android

### DIFF
--- a/app/StopPicker/View.elm
+++ b/app/StopPicker/View.elm
@@ -1,6 +1,7 @@
 module StopPicker.View exposing (view)
 
 import Json.Encode
+import NativeApi.Platform as Platform exposing (OS(..))
 import NativeUi as Ui exposing (Node, Property, property)
 import NativeUi.Style as Style exposing (defaultTransform)
 import NativeUi.Elements as Elements exposing (..)
@@ -20,6 +21,7 @@ view dataSource =
     pickerContainer
         [ pickerHeader "Select home stop"
         , stopOptions dataSource
+        , androidBorderRadiusHack
         ]
 
 
@@ -60,6 +62,27 @@ pickerHeader label =
             ]
             [ Ui.string label ]
         ]
+
+
+androidBorderRadiusHack : Node Msg
+androidBorderRadiusHack =
+    let
+        styles =
+            case Platform.os of
+                Android ->
+                    [ Style.borderBottomLeftRadius 10
+                    , Style.borderBottomRightRadius 10
+                    , Style.backgroundColor Color.white
+                    , Style.height 10
+                    ]
+
+                IOS ->
+                    []
+    in
+        Elements.view
+            [ Ui.style styles
+            ]
+            []
 
 
 pickerContainer : List (Node Msg) -> Node Msg


### PR DESCRIPTION
Fixes https://github.com/thoughtbot/PurpleTrainElm/issues/46

For some reason the bottom of the stops list renders with ugly square
corners on Android instead of the specified border radius from the
picker container.

This hack adds a 10px empty view below the list view for Android, with
border radius set.

Hopefully we can remove this at some point in favor of a better
solution. This is barely better than the square corners, since the list view scrolls underneath the 10px view, which makes the text look cut off when scrolling through.

## Before

![screenshot_20170224-163522](https://cloud.githubusercontent.com/assets/180798/23322065/4e86e00c-fab0-11e6-9d8c-cb6b368d36a8.png)

## After

![screenshot_20170224-163433](https://cloud.githubusercontent.com/assets/180798/23322070/542562e0-fab0-11e6-8045-0b8779227a42.png)