### PR TITLE
Use different arrow characters

### DIFF
--- a/app/Schedule/Alerts/View.elm
+++ b/app/Schedule/Alerts/View.elm
@@ -59,6 +59,7 @@ alertsBanner alertsAreExpanded alertCount =
             [ Ui.style
                 [ Style.flex 1
                 , Style.color Color.white
+                , Style.fontSize 26
                 ]
             ]
             [ Ui.string <| arrowCharacter alertsAreExpanded ]
@@ -153,6 +154,6 @@ alertsBannerText alertCount =
 arrowCharacter : Bool -> String
 arrowCharacter alertsAreExpanded =
     if alertsAreExpanded then
-        "▼"
+        "⇣"
     else
-        "▶"
+        "⇢"


### PR DESCRIPTION
The previous right-facing arrow was rendering as the emoji with the blue
rounded container: ➡️️ on iOS 9.x. This changes the arrow characters to
ones that don't render as emoji on iOS 9.x.

See
http://stackoverflow.com/questions/11178433/how-do-i-stop-ios-from-converting-a-small-pointing-right-triangle-character-into

Fixes https://github.com/thoughtbot/PurpleTrainElm/issues/54

## New arrows:
![purple_train_new_arrow](https://cloud.githubusercontent.com/assets/180798/23558317/209abb5e-0001-11e7-81da-1690ba3bf04c.gif)
