### PR TITLE
Refactor Update module

### DIFF
--- a/app/App/Maybe.elm
+++ b/app/App/Maybe.elm
@@ -1,4 +1,6 @@
-module App.Maybe exposing (catMaybes, join)
+module App.Maybe exposing (catMaybes, join, maybeToCommand)
+
+import Message exposing (Msg)
 
 
 catMaybes : List (Maybe a) -> List a
@@ -14,3 +16,9 @@ join mx =
 
         Nothing ->
             Nothing
+
+
+maybeToCommand : (a -> Cmd Msg) -> Maybe a -> Cmd Msg
+maybeToCommand toCommand m =
+    Maybe.map toCommand m
+        |> Maybe.withDefault Cmd.none

--- a/app/App/Settings.elm
+++ b/app/App/Settings.elm
@@ -6,15 +6,11 @@ module App.Settings
         , stopKey
         , stop
         , dismissedAlertIds
-        , Settings
         )
 
 import Dict exposing (Dict)
 import App.Maybe exposing (join)
-
-
-type Settings
-    = Settings (Dict String (Maybe String))
+import Types exposing (..)
 
 
 fromDict : Dict String (Maybe String) -> Settings

--- a/app/App/Settings/Update.elm
+++ b/app/App/Settings/Update.elm
@@ -1,0 +1,29 @@
+module App.Settings.Update exposing (..)
+
+import App.Settings as Settings
+import App.Maybe exposing (maybeToCommand)
+import FetchAlertsAndSchedules exposing (fetchAlertsAndSchedules)
+import Message exposing (..)
+import Model exposing (Model)
+import Types exposing (..)
+
+
+receiveSettings : Model -> SettingsResult -> ( Model, Cmd Msg )
+receiveSettings model settingsResult =
+    case settingsResult of
+        Err _ ->
+            ( model, Cmd.none )
+
+        Ok settings ->
+            ( { model
+                | dismissedAlertIds = Settings.dismissedAlertIds settings
+                , selectedStop = Settings.stop settings
+              }
+            , onReceiveSettings settings
+            )
+
+
+onReceiveSettings : Settings -> Cmd Msg
+onReceiveSettings settings =
+    Settings.stop settings
+        |> maybeToCommand fetchAlertsAndSchedules

--- a/app/FetchAlerts.elm
+++ b/app/FetchAlerts.elm
@@ -1,16 +1,15 @@
-module FetchAlerts exposing (..)
+module FetchAlerts exposing (fetchAlerts)
 
 import Http
 import Json.Decode as Decode
 import Message exposing (..)
-import Model exposing (..)
 import Types exposing (..)
 import Api exposing (..)
 
 
 fetchAlerts : Stop -> Cmd Msg
 fetchAlerts stop =
-    Http.send LoadAlerts <| getAlerts stop
+    Http.send ReceiveAlerts <| getAlerts stop
 
 
 getAlerts : String -> Http.Request Alerts

--- a/app/FetchAlertsAndSchedules.elm
+++ b/app/FetchAlertsAndSchedules.elm
@@ -1,0 +1,15 @@
+module FetchAlertsAndSchedules exposing (..)
+
+import FetchAlerts exposing (fetchAlerts)
+import FetchSchedule exposing (fetchSchedule)
+import Message exposing (..)
+import Types exposing (..)
+
+
+fetchAlertsAndSchedules : Stop -> Cmd Msg
+fetchAlertsAndSchedules stop =
+    Cmd.batch
+        [ fetchSchedule Inbound stop
+        , fetchSchedule Outbound stop
+        , fetchAlerts stop
+        ]

--- a/app/FetchSchedule.elm
+++ b/app/FetchSchedule.elm
@@ -3,7 +3,6 @@ module FetchSchedule exposing (fetchSchedule)
 import Http
 import Date exposing (Date)
 import Json.Decode as Decode
-import Model exposing (..)
 import Message exposing (..)
 import Types exposing (..)
 import Api exposing (..)
@@ -11,7 +10,7 @@ import Api exposing (..)
 
 fetchSchedule : Direction -> Stop -> Cmd Msg
 fetchSchedule direction stop =
-    Http.send (LoadSchedule direction) (getSchedule direction stop)
+    Http.send (ReceiveSchedule direction) (getSchedule direction stop)
 
 
 getSchedule : Direction -> Stop -> Http.Request Schedule

--- a/app/FetchStops.elm
+++ b/app/FetchStops.elm
@@ -9,7 +9,7 @@ import Api exposing (..)
 
 fetchStops : Cmd Msg
 fetchStops =
-    Http.send LoadStops getStops
+    Http.send ReceiveStops getStops
 
 
 getStops : Http.Request Stops

--- a/app/Message.elm
+++ b/app/Message.elm
@@ -4,24 +4,18 @@ import Http
 import Time exposing (Time)
 import Types exposing (..)
 import NativeUi.AsyncStorage as AsyncStorage
-import App.Settings exposing (Settings)
-
-
-type alias SettingsResult =
-    Result AsyncStorage.Error Settings
 
 
 type Msg
-    = PickStop Stop
-    | LoadStops (Result Http.Error Stops)
-    | LoadSchedule Direction (Result Http.Error Schedule)
-    | ToggleStopPicker
-    | SetItem (Result AsyncStorage.Error ())
-    | GetItem (Result AsyncStorage.Error (Maybe String))
-    | Tick Time
-    | ReportIssue Direction (Maybe Stop)
-    | IssueResponse (Result Http.Error ())
-    | ToggleAlerts
-    | LoadAlerts (Result Http.Error Alerts)
-    | DismissAlert Alert
+    = DismissAlert Alert
+    | PickStop Stop
+    | ReceiveAlerts (Result Http.Error Alerts)
+    | ReceiveIssueResponse (Result Http.Error ())
+    | ReceiveSchedule Direction (Result Http.Error Schedule)
     | ReceiveSettings SettingsResult
+    | ReceiveStops (Result Http.Error Stops)
+    | ReportIssue Direction (Maybe Stop)
+    | SetItem (Result AsyncStorage.Error ())
+    | Tick Time
+    | ToggleAlerts
+    | ToggleStopPicker

--- a/app/ReportIssue.elm
+++ b/app/ReportIssue.elm
@@ -10,7 +10,7 @@ import Json.Encode as Encode
 
 report : Direction -> Stop -> Cmd Msg
 report direction =
-    Http.send IssueResponse << postReport direction
+    Http.send ReceiveIssueResponse << postReport direction
 
 
 reportUrlEndpoint : String

--- a/app/Schedule/Alerts/Update.elm
+++ b/app/Schedule/Alerts/Update.elm
@@ -1,0 +1,37 @@
+module Schedule.Alerts.Update exposing (dismissAlert)
+
+import NativeUi.AsyncStorage as AsyncStorage
+import Message exposing (Msg(..))
+import Model exposing (Model, visibleAlertsExist)
+import App.Settings as Settings
+import Task
+import Types exposing (..)
+
+
+dismissAlert : Model -> Alert -> ( Model, Cmd Msg )
+dismissAlert model alert =
+    let
+        newDismissedAlertIds =
+            alert.id :: model.dismissedAlertIds
+
+        command =
+            saveDismissedAlertsCommand newDismissedAlertIds
+
+        modelWithDismissedAlert =
+            { model | dismissedAlertIds = newDismissedAlertIds }
+    in
+        if visibleAlertsExist modelWithDismissedAlert then
+            ( modelWithDismissedAlert, command )
+        else
+            ( { modelWithDismissedAlert | alertsAreExpanded = False }, command )
+
+
+saveDismissedAlertsCommand : List Int -> Cmd Msg
+saveDismissedAlertsCommand dismissedAlertIds =
+    let
+        dismissedAlertIdsCsv =
+            String.join "," <| List.map toString dismissedAlertIds
+    in
+        Task.attempt
+            SetItem
+            (AsyncStorage.setItem Settings.dismissedAlertsKey dismissedAlertIdsCsv)

--- a/app/Stops/Update.elm
+++ b/app/Stops/Update.elm
@@ -1,0 +1,48 @@
+module Stops.Update exposing (receiveStops, pickStop)
+
+import Http
+import NativeUi.AsyncStorage as AsyncStorage
+import NativeUi.ListView exposing (updateDataSource, emptyDataSource)
+import Task
+import App.Settings as Settings
+import FetchAlertsAndSchedules exposing (fetchAlertsAndSchedules)
+import Message exposing (Msg(..))
+import Model exposing (Model)
+import Types exposing (..)
+
+
+receiveStops : Model -> Result Http.Error Stops -> ( Model, Cmd Msg )
+receiveStops model result =
+    let
+        stopPickerDataSource =
+            case ( result, model.stopPickerDataSource ) of
+                ( Ok stops, Ready originalDataSource ) ->
+                    Ready (updateDataSource originalDataSource stops)
+
+                ( Ok stops, _ ) ->
+                    Ready (updateDataSource emptyDataSource stops)
+
+                ( Err _, Ready originalDataSource ) ->
+                    model.stopPickerDataSource
+
+                ( Err e, _ ) ->
+                    Error
+    in
+        ( { model | stopPickerDataSource = stopPickerDataSource }, Cmd.none )
+
+
+pickStop : Model -> Stop -> ( Model, Cmd Msg )
+pickStop model stop =
+    ( { model
+        | selectedStop = Just stop
+        , stopPickerOpen = False
+        , inboundSchedule = Loading
+        , outboundSchedule = Loading
+      }
+    , Cmd.batch <|
+        [ Task.attempt
+            SetItem
+            (AsyncStorage.setItem Settings.stopKey stop)
+        , fetchAlertsAndSchedules stop
+        ]
+    )

--- a/app/Tick/Update.elm
+++ b/app/Tick/Update.elm
@@ -1,0 +1,29 @@
+module Tick.Update exposing (tick)
+
+import Date exposing (Date)
+import Time exposing (Time)
+import FetchAlertsAndSchedules exposing (fetchAlertsAndSchedules)
+import FetchStops exposing (..)
+import Message exposing (..)
+import Model exposing (Model)
+import Types exposing (..)
+
+
+tick : Model -> Time -> ( Model, Cmd Msg )
+tick model now =
+    ( { model | now = Date.fromTime now }
+    , tickCommand model
+    )
+
+
+tickCommand : Model -> Cmd Msg
+tickCommand model =
+    case ( model.selectedStop, model.stopPickerDataSource ) of
+        ( Nothing, Error ) ->
+            fetchStops
+
+        ( Just selectedStop, _ ) ->
+            fetchAlertsAndSchedules selectedStop
+
+        _ ->
+            Cmd.none

--- a/app/Types.elm
+++ b/app/Types.elm
@@ -1,6 +1,8 @@
 module Types exposing (..)
 
 import Date exposing (Date)
+import NativeUi.AsyncStorage as AsyncStorage
+import Dict exposing (Dict)
 
 
 type Direction
@@ -44,3 +46,11 @@ type Loadable a
     = Loading
     | Error
     | Ready a
+
+
+type Settings
+    = Settings (Dict String (Maybe String))
+
+
+type alias SettingsResult =
+    Result AsyncStorage.Error Settings


### PR DESCRIPTION
This refactors the Update module by:
- Extracting functions from `update` into separate modules
- Renaming "load" actions to "receive" to reduce ambiguity
- Removing obsolete `GetItem` action. This is unnecessary now that we
  load all settings at once using `ReceiveSettings`. Removing `GetItem`
  required that we fire a command in `ReceiveSettings` to fetch alerts
  and the schedule as soon as we have the selected stop (loaded from
  settings)

Elm is a treat to refactor :)

Fixes https://github.com/thoughtbot/PurpleTrainElm/issues/56