### PR TITLE
URI encode the stop id when fetching alerts

### DIFF
--- a/app/FetchAlerts.elm
+++ b/app/FetchAlerts.elm
@@ -15,7 +15,11 @@ fetchAlerts stop =
 getAlerts : String -> Http.Request Alerts
 getAlerts stopId =
     Http.get
-        (baseUrl ++ "/api/v2/stops/" ++ stopId ++ "/alerts")
+        (baseUrl
+            ++ "/api/v2/stops/"
+            ++ (Http.encodeUri stopId)
+            ++ "/alerts"
+        )
         decodeAlerts
 
 


### PR DESCRIPTION
This URI encodes the stop id query param when fetching alerts
so the phoenix router parses the URL correctly when the stop has
slashes in the name, like "Forge Park / 495".